### PR TITLE
Allow dev containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # keep these
 !**/.gitignore
+!/.devcontainer/
 !/.eslintrc.js
 !/.github/
 !/.gitignore


### PR DESCRIPTION
To be discussed of course, but this PR gets the ball rolling on that. This would allow the standardized `.devcontainer` folders to be commited to repos

This will allow us to suggest a simple isolated local dev enviro (ideally matching prod env in terms of say linux/node/etc versions)

For instance i have set this up with the apiv1 auth branch locally and it sets up a dev docker container with postgres, nvm etc ready to roll using a simple json & docker compose file