### PR TITLE
feat: add mustache generator and use it for ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !/.github/
 !/.gitignore
 !/.npmrc
+!/Dockerfile
 !/bin/
 !/CHANGELOG*
 !/docs/
@@ -23,7 +24,6 @@
 !/tap-snapshots/
 !/test/
 !/tsconfig*.json
-!Dockerfile
 
 # re-ignore typescript output artifacts
 /knexfile.js

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -38,6 +38,22 @@ jobs:
     defaults:
       run:
         shell: bash
+    <%#postgres%>
+    services:
+      postgres:
+        image: "postgres:14"
+        env:
+          POSTGRES_USER: ${{ vars.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ vars.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ vars.POSTGRES_DB }}
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+        - "${{ vars.POSTGRES_PORT }}:5432"
+    <%/postgres%>
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -52,4 +68,8 @@ jobs:
       - name: Add tap problem matcher
         run: echo "::add-matcher::.github/matchers/tap.json"
       - name: Test
+        <%#env_vault%>
+        env:
+          DOTENV_KEY: ${{ secrets.DOTENV_KEY }}
+        <%/env_vault%>
         run: npm test --ignore-scripts

--- a/lib/content/gitignore
+++ b/lib/content/gitignore
@@ -4,10 +4,12 @@
 
 # keep these
 !**/.gitignore
+!/.devcontainer/
 !/.eslintrc.js
 !/.github/
 !/.gitignore
 !/.npmrc
+!/Dockerfile
 !/bin/
 !/CHANGELOG*
 !/docs/

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -53,7 +53,7 @@ export default async function (root: string, variables: Variables) {
       },
       types: "lib/index.d.ts",
       devDependencies: {
-        "@tsconfig/node18": "^2.0.0",
+        "@tsconfig/node18": "^18.0.0",
         "@types/mustache": "^4.0.0",
         "@types/node": "^18.0.0",
         "@types/tap": "^15.0.0",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "node:path";
 import { readFileSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { copy, json, pkg, type Skeleton } from "code-skeleton";
+import { mustache } from "./mustache";
 
 const ownPkg = JSON.parse(
   readFileSync(join(dirname(__dirname), "package.json"), { encoding: "utf8" })
@@ -10,6 +11,7 @@ const ownPkg = JSON.parse(
 interface Variables {
   dogfood?: boolean;
   library?: boolean;
+  ci?: object;
 }
 
 export default async function (root: string, variables: Variables) {
@@ -52,11 +54,13 @@ export default async function (root: string, variables: Variables) {
       types: "lib/index.d.ts",
       devDependencies: {
         "@tsconfig/node18": "^2.0.0",
+        "@types/mustache": "^4.0.0",
         "@types/node": "^18.0.0",
         "@types/tap": "^15.0.0",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^8.0.0",
+        "mustache": "^4.0.0",
         "tap": "^16.0.0",
         "ts-node": "^10.0.0",
         "typescript": "^5.0.0"
@@ -94,7 +98,7 @@ export default async function (root: string, variables: Variables) {
     ".eslintrc.js": copy(join(__dirname, "content", "eslintrc.js")),
     ".gitignore": copy(join(__dirname, "content", "gitignore")),
     "scripts/clean.ts": copy(join(__dirname, "content", "clean.ts")),
-    ".github/workflows/ci.yml": copy(join(__dirname, "content", "ci.yml")),
+    ".github/workflows/ci.yml": mustache(join(__dirname, "content", "ci.yml"), variables.ci),
     ".github/matchers/tap.json": copy(join(__dirname, "content", "tap.json")),
   };
 

--- a/lib/mustache.ts
+++ b/lib/mustache.ts
@@ -1,0 +1,69 @@
+import {
+  Generator,
+  GeneratorResults,
+  GeneratorOptions
+} from "code-skeleton/lib/generators/abstract";
+import { dirname } from "node:path";
+import { writeFile, mkdir, readFile } from "node:fs/promises";
+import Mustache from "mustache";
+Mustache.tags = [ "<%", "%>" ];
+
+interface MustacheGeneratorOptions extends GeneratorOptions {
+  sourcePath: string;
+}
+
+class MustacheGenerator extends Generator {
+  declare options: MustacheGeneratorOptions;
+
+  constructor (options: MustacheGeneratorOptions) {
+    super(options);
+
+    if (!this.options.sourcePath) {
+      throw new Error("Must specify a source path");
+    }
+  }
+
+  async apply(targetPath: string): Promise<GeneratorResults> {
+    await mkdir(dirname(targetPath), { recursive: true });
+    try {
+      const source = await readFile(this.options.sourcePath);
+
+      const rendered = Mustache.render(source.toString(), this.options);
+      await writeFile(targetPath, rendered);
+      return this.pass();
+    } catch (err) {
+      const { code, message } = err as { code?: string; message: string };
+      // istanbul ignore next - no need to test message fallback
+      return this.fail(code ?? message);
+    }
+  }
+  async verify(targetPath: string): Promise<GeneratorResults> {
+    let actual;
+    try {
+      actual = await readFile(targetPath);
+    } catch (err) {
+      const { code, message } = err as { code?: string; message: string };
+      // istanbul ignore next - no need to test passthrough throws
+      if (code !== "ENOENT") {
+        return this.fail(code ?? message);
+      }
+
+      return this.fail("file missing");
+    }
+
+    const source = await readFile(this.options.sourcePath);
+    const expected = Buffer.from(Mustache.render(source.toString(), this.options));
+    if (actual.compare(expected) === 0) {
+      return this.pass();
+    }
+
+    return this.fail("contents do not match");
+  }
+}
+
+export function mustache (sourcePath: string, options: GeneratorOptions = {}) {
+  return new MustacheGenerator({
+    ...options,
+    sourcePath
+  });
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Nathan LaFreniere <nlf@nlf.sh>",
   "license": "ISC",
   "devDependencies": {
-    "@tsconfig/node18": "^2.0.0",
+    "@tsconfig/node18": "^18.0.0",
     "@types/mustache": "^4.0.0",
     "@types/node": "^18.0.0",
     "@types/tap": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
   "license": "ISC",
   "devDependencies": {
     "@tsconfig/node18": "^2.0.0",
+    "@types/mustache": "^4.0.0",
     "@types/node": "^18.0.0",
     "@types/tap": "^15.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.0",
+    "mustache": "^4.0.0",
     "tap": "^16.0.0",
     "ts-node": "^10.0.0",
     "typescript": "^5.0.0"
@@ -34,7 +36,11 @@
   "skeleton": {
     "module": ".",
     "variables": {
-      "library": true
+      "library": true,
+      "ci": {
+        "postgres": false,
+        "env_vault": false
+      }
     }
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "typeRoots": [
       "./node_modules/@types",
       "./lib/types"
-    ]
+    ],
+    "moduleResolution": "node16"
   },
   "//": "This file is partially managed by code-skeleton. Changes may be overwritten."
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,7 @@
     "typeRoots": [
       "./node_modules/@types",
       "./lib/types"
-    ],
-    "moduleResolution": "node16"
+    ]
   },
   "//": "This file is partially managed by code-skeleton. Changes may be overwritten."
 }


### PR DESCRIPTION
## Summary
This adds a mustache generator for injecting variables into files. This generator is currently used to optionally include a postgres service during the test phase of CI, as well as optionally being able to include the `DOTENV_KEY` env key for projects using dotenv vault in CI.

I ended up using Mustache as the generator as it has no dependencies, but I have no strong feelings on it, so happy to switch out if there is a preference for something else.

`package.json` includes all the available variables set to false. Updating them to true and running apply results in this diff:
```diff
     defaults:
       run:
         shell: bash
+    services:
+      postgres:
+        image: "postgres:14"
+        env:
+          POSTGRES_USER: ${{ vars.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ vars.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ vars.POSTGRES_DB }}
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+        - "${{ vars.POSTGRES_PORT }}:5432"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -52,4 +66,6 @@ jobs:
       - name: Add tap problem matcher
         run: echo "::add-matcher::.github/matchers/tap.json"
       - name: Test
+        env:
+          DOTENV_KEY: ${{ secrets.DOTENV_KEY }}
         run: npm test --ignore-scripts
diff --git a/package.json b/package.json
index 898d3c2..2b180d6 100644
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "variables": {
       "library": true,
       "ci": {
-        "postgres": false,
-        "env_vault": false
+        "postgres": true,
+        "env_vault": true
       }
     }
   },
```

### Other fixes
* #3 and #4 update .gitignore itself but not the template file, this updates the template file to include them. Apply has been run to update the projects .gitignore from the template.
* I was getting errors with tsconfig locally which also prevented lint and other things from running. Adding moduleResolution resolves the problem. Turns out `@tsconfig/node18` was way out of date, so I bumped the major to 18 which resolved the problem.

## Refs
* https://github.com/code4rena-dev/api-v1/pull/15 has the latest changes in this PR applied.