### PR TITLE
feat: add .nomad folder to .gitignore as keep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 !/knexfile.ts
 !/lib/
 !/migrations/
+!/.nomad/
 !/LICENSE*
 !/package.json
 !/README*

--- a/lib/content/gitignore
+++ b/lib/content/gitignore
@@ -16,6 +16,7 @@
 !/knexfile.ts
 !/lib/
 !/migrations/
+!/.nomad/
 !/LICENSE*
 !/package.json
 !/README*


### PR DESCRIPTION
That .nomad folder is used to house nomad job files for continuous deployment pipelines.