### PR TITLE
feat: allow ci files to be partials so they can be extended

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -98,7 +98,7 @@ export default async function (root: string, variables: Variables) {
     "scripts/clean.ts": copy(join(__dirname, "content", "clean.ts")),
     ".github/workflows/ci.yml": mustache({
       sourcePath: join(__dirname, "content", "ci.yml"),
-      variables,
+      variables: variables.ci,
     }),
     ".github/matchers/tap.json": copy(join(__dirname, "content", "tap.json")),
   };

--- a/lib/mustache.ts
+++ b/lib/mustache.ts
@@ -1,4 +1,5 @@
-import { Generator } from "code-skeleton/lib/generators/abstract";
+import { Generator, ValidateInput } from "code-skeleton/lib/generators/abstract";
+import { GeneratorReportResult } from "code-skeleton/lib/generators/report";
 import { readFile } from "node:fs/promises";
 import Mustache from "mustache";
 Mustache.tags = [ "<%", "%>" ];
@@ -24,6 +25,20 @@ class MustacheGenerator extends Generator<MustacheGeneratorOptions> {
 
     const rendered = Mustache.render(source.toString(), this.options.variables);
     return rendered;
+  }
+
+  async validate(options: ValidateInput) : Promise<GeneratorReportResult> {
+    const expected = await this.generate();
+
+    if (!options.found.includes(expected)) {
+      this.report({
+        expected,
+        found: options.found,
+        message: `${this.options.sourcePath} does not include the original template`
+      });
+      return GeneratorReportResult.Fail;
+    }
+    return GeneratorReportResult.Pass;
   }
 }
 


### PR DESCRIPTION
This gives us some more flexibility without breaking linting, and the base template is still required to be included. In particular this lets us do things like play around with the new deployment CI before needing to reintegrate it back here.


This also resolves an issue with the ci variables not being passed in correctly.