### PR TITLE
feat: replace ts-node shebangs with node ones in published bins

### DIFF
--- a/lib/content/update-shebang.ts
+++ b/lib/content/update-shebang.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env ts-node
+
+import { spawnSync } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+const ROOT = dirname(__dirname);
+const tsShebang = "#!/usr/bin/env ts-node";
+const jsShebang = "#!/usr/bin/env node";
+
+async function updateShebang (path: string) {
+  const originalContent = await readFile(path, { encoding: "utf8" });
+  const updatedContent = originalContent.replace(tsShebang, jsShebang);
+  await writeFile(path, updatedContent, { encoding: "utf8" });
+}
+
+async function main () {
+  const npmResult = spawnSync("npm", ["show", ".", "bin", "--json"], {
+    cwd: ROOT,
+    shell: true,
+    encoding: "utf8",
+  });
+
+  if (npmResult.stdout) {
+    const binEntries = JSON.parse(npmResult.stdout) as Record<string, string>;
+    const binPaths = Object.values(binEntries);
+
+    for (const binPath of binPaths) {
+      await updateShebang(resolve(ROOT, binPath));
+    }
+  }
+}
+
+main().catch((err: Error) => {
+  process.exitCode = 1;
+  console.error(err.stack);
+});

--- a/scripts/update-shebang.ts
+++ b/scripts/update-shebang.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env ts-node
+
+import { spawnSync } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+const ROOT = dirname(__dirname);
+const tsShebang = "#!/usr/bin/env ts-node";
+const jsShebang = "#!/usr/bin/env node";
+
+async function updateShebang (path: string) {
+  const originalContent = await readFile(path, { encoding: "utf8" });
+  const updatedContent = originalContent.replace(tsShebang, jsShebang);
+  await writeFile(path, updatedContent, { encoding: "utf8" });
+}
+
+async function main () {
+  const npmResult = spawnSync("npm", ["show", ".", "bin", "--json"], {
+    cwd: ROOT,
+    shell: true,
+    encoding: "utf8",
+  });
+
+  if (npmResult.stdout) {
+    const binEntries = JSON.parse(npmResult.stdout) as Record<string, string>;
+    const binPaths = Object.values(binEntries);
+
+    for (const binPath of binPaths) {
+      await updateShebang(resolve(ROOT, binPath));
+    }
+  }
+}
+
+main().catch((err: Error) => {
+  process.exitCode = 1;
+  console.error(err.stack);
+});


### PR DESCRIPTION
this updates

```
#!/usr/bin/env ts-node
```

with

```
#!/usr/bin/env node
```

in defined `bin` scripts that are present in `package.json`, this facilitates development since you can run the uncompiled `bin.ts` but at publish time ensures that `bin.js` has the correct shebang
