### PR TITLE
fix: shebang should support non published modules

### DIFF
--- a/lib/content/update-shebang.ts
+++ b/lib/content/update-shebang.ts
@@ -15,7 +15,7 @@ async function updateShebang (path: string) {
 }
 
 async function main () {
-  const npmResult = spawnSync("npm", ["show", ".", "bin", "--json"], {
+  const npmResult = spawnSync("npm", ["show", `file://${ROOT}`, "bin", "--json"], {
     cwd: ROOT,
     shell: true,
     encoding: "utf8",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -117,7 +117,7 @@ export default async function (root: string, variables: Variables) {
     ".gitignore": copy(join(__dirname, "content", "gitignore")),
     "scripts/clean.ts": copy(join(__dirname, "content", "clean.ts")),
     ".github/workflows/ci.yml": mustache({
-      sourcePath: join(__dirname, "content", "ci.yml"),
+      path: join(__dirname, "content", "ci.yml"),
       variables: variables.ci || {},
     }),
     ".github/matchers/tap.json": copy(join(__dirname, "content", "tap.json")),

--- a/lib/mustache.ts
+++ b/lib/mustache.ts
@@ -1,11 +1,10 @@
-import { Generator, ValidateInput } from "code-skeleton/lib/generators/abstract";
-import { GeneratorReportResult } from "code-skeleton/lib/generators/report";
+import { Generator } from "code-skeleton/lib/generators/abstract";
 import { readFile } from "node:fs/promises";
 import Mustache from "mustache";
 Mustache.tags = [ "<%", "%>" ];
 
 interface MustacheGeneratorOptions {
-  sourcePath: string;
+  path: string;
   variables: unknown;
 }
 
@@ -15,30 +14,16 @@ class MustacheGenerator extends Generator<MustacheGeneratorOptions> {
   constructor (options: MustacheGeneratorOptions) {
     super(options);
 
-    if (!this.options.sourcePath) {
+    if (!this.options.path) {
       throw new Error("Must specify a source path");
     }
   }
 
   async generate () {
-    const source = await readFile(this.options.sourcePath);
+    const source = await readFile(this.options.path);
 
     const rendered = Mustache.render(source.toString(), this.options.variables);
     return rendered;
-  }
-
-  async validate(options: ValidateInput) : Promise<GeneratorReportResult> {
-    const expected = await this.generate();
-
-    if (!options.found.includes(expected)) {
-      this.report({
-        expected,
-        found: options.found,
-        message: `${this.options.sourcePath} does not include the original template`
-      });
-      return GeneratorReportResult.Fail;
-    }
-    return GeneratorReportResult.Pass;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "^8.0.0",
     "tap": "^16.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "code-skeleton": "^2.0.0"

--- a/scripts/update-shebang.ts
+++ b/scripts/update-shebang.ts
@@ -15,7 +15,7 @@ async function updateShebang (path: string) {
 }
 
 async function main () {
-  const npmResult = spawnSync("npm", ["show", ".", "bin", "--json"], {
+  const npmResult = spawnSync("npm", ["show", `file://${ROOT}`, "bin", "--json"], {
     cwd: ROOT,
     shell: true,
     encoding: "utf8",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,6 @@
+import t from "tap";
+
+void t.test("this is not a real test", (t) => {
+  t.pass();
+  t.end();
+});


### PR DESCRIPTION
## Summary
We can tell `npm show` to use the local package.json instead of trying to resolve the package name via the npm registry. 

* Also makes CI function here so I can stop missing `./lib/content` updates.


### Shebang Chmod
Note: right now after doing a `skeleton:apply` if you have bin entries in your package.json you will have to `./scripts/update-shebang.ts` for the time being. We need to update code-skeleton as a followup to allow passing a permissions option to resolve this.