### PR TITLE
Update CI to run potential integration test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,11 @@ jobs:
         run: echo "::add-matcher::.github/matchers/tap.json"
       - name: Test
         run: npm test --ignore-scripts
+      - name: Weekly Integration Tests
+        if: github.event_name == 'schedule'
+        run: |
+          if npm run --silent | grep -q "test:integration"; then
+            npm run test:integration --ignore-scripts
+          else
+            echo "No integration tests to run, skipping..."
+          fi

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -75,7 +75,14 @@ jobs:
           DOTENV_KEY: ${{ secrets.DOTENV_KEY }}
         <%/env_vault%>
         run: npm test --ignore-scripts
-
+     - name: Weekly Integration Tests
+        if: github.event_name == 'schedule'
+        run: |
+          if npm run --silent | grep -q "test:integration"; then
+            npm run test:integration --ignore-scripts
+          else
+            echo "No integration tests to run, skipping..."
+          fi
   weekly_test:
     name: Weekly Full Test
     runs-on: ubuntu-latest

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -75,3 +75,33 @@ jobs:
           DOTENV_KEY: ${{ secrets.DOTENV_KEY }}
         <%/env_vault%>
         run: npm test --ignore-scripts
+
+  weekly_test:
+    name: Weekly Full Test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: Update npm
+        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - name: Install dependencies
+        run: npm i --no-audit --no-fund
+      - name: Check if test:full is defined
+        id: check_test_full
+        run: |
+          if grep -q '"test:full":' package.json; then
+            echo "::set-output name=exists::true"
+          else
+            echo "::set-output name=exists::false"
+          fi
+      - name: Run Full Test
+        if: steps.check_test_full.outputs.exists == 'true'
+        run: npm run test:full --ignore-scripts

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -75,7 +75,7 @@ jobs:
           DOTENV_KEY: ${{ secrets.DOTENV_KEY }}
         <%/env_vault%>
         run: npm test --ignore-scripts
-     - name: Weekly Integration Tests
+      - name: Weekly Integration Tests
         if: github.event_name == 'schedule'
         run: |
           if npm run --silent | grep -q "test:integration"; then
@@ -83,32 +83,3 @@ jobs:
           else
             echo "No integration tests to run, skipping..."
           fi
-  weekly_test:
-    name: Weekly Full Test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-      - name: Update npm
-        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
-      - name: Install dependencies
-        run: npm i --no-audit --no-fund
-      - name: Check if test:full is defined
-        id: check_test_full
-        run: |
-          if grep -q '"test:full":' package.json; then
-            echo "::set-output name=exists::true"
-          else
-            echo "::set-output name=exists::false"
-          fi
-      - name: Run Full Test
-        if: steps.check_test_full.outputs.exists == 'true'
-        run: npm run test:full --ignore-scripts


### PR DESCRIPTION
The purpose of this PR is to allow the skeleton user to have 2 different test suite:

1) The unit tests, running as normal with `npm run test` based on their `tap` config. This suite doesn't expect environment variables

2) The integration tests, I propose to have a second ( optional ) command in the project using the skeleton: `npm run test:full` that would be pointing to both the integration and the unit tests. 

This way, we can reduce the amount of calls potentially using tokens on each commit. 

