### PR TITLE
feat: update tap to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Update npm
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Update npm
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !/.gitignore
 !/.npmrc
 !/.prettierrc.json
+!/.taprc
 !/Dockerfile
 !/bin/
 !/CHANGELOG*

--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,6 @@
+# vim: set filetype=yaml :
+disable-coverage: false
+allow-incomplete-coverage: false
+plugin:
+  - "@tapjs/sinon"
+  - "!@tapjs/intercept"

--- a/.taprc
+++ b/.taprc
@@ -4,3 +4,5 @@ allow-incomplete-coverage: false
 plugin:
   - "@tapjs/sinon"
   - "!@tapjs/intercept"
+  - "@tapjs/tsx"
+  - "!@tapjs/typescript"

--- a/.taprc
+++ b/.taprc
@@ -1,8 +1,11 @@
 # vim: set filetype=yaml :
 disable-coverage: false
-allow-incomplete-coverage: false
+allow-empty-coverage: true
+allow-incomplete-coverage: true
 plugin:
   - "@tapjs/sinon"
   - "!@tapjs/intercept"
   - "@tapjs/tsx"
   - "!@tapjs/typescript"
+color: true
+reporter: base

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
 
 ## Configuration & Usage
 
+**Important Note** on '@tsconfig/node18/tsconfig.json' not found, and Tap:
+
+There is currently an [issue](https://github.com/tapjs/tapjs/issues/976) in ts-node that causes a loading problem when combined with Tap.js. There is a [recommended](https://github.com/tapjs/tapjs/issues/976#issuecomment-1824784507) workaround for this. Once you update your skeleton, swap out these plugins:
+
+```
+npx tap plugin add @tapjs/tsx
+npx tap plugin rm @tapjs/typescript
+```
+
+
 ### CI
 In your projects `package.json` you can set custom CI variables to extend the default workflow. The following configuration will add a Postgres service to the test job, as well as inject the `DOTENV_KEY` environment variables for dotenv vault usage.
 

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Update npm
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Update npm
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
       - name: Install dependencies

--- a/lib/content/clean.ts
+++ b/lib/content/clean.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env tsx
 // This file is managed by code-skeleton. Do not make changes.
 
 import { rmSync } from "node:fs";

--- a/lib/content/gitignore
+++ b/lib/content/gitignore
@@ -10,6 +10,7 @@
 !/.gitignore
 !/.npmrc
 !/.prettierrc.json
+!/.taprc
 !/Dockerfile
 !/bin/
 !/CHANGELOG*

--- a/lib/content/update-shebang.ts
+++ b/lib/content/update-shebang.ts
@@ -1,11 +1,11 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env tsx
 
 import { spawnSync } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
 const ROOT = dirname(__dirname);
-const tsShebang = "#!/usr/bin/env ts-node";
+const tsShebang = "#!/usr/bin/env tsx";
 const jsShebang = "#!/usr/bin/env node";
 
 async function updateShebang (path: string) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -71,7 +71,7 @@ export default async function (root: string, variables: Variables) {
       types: "lib/index.d.ts",
       devDependencies: {
         "@tsconfig/node20": "^20.0.0",
-        "@types/node": "^18.0.0",
+        "@types/node": "^20.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.0.0",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -69,7 +69,7 @@ export default async function (root: string, variables: Variables) {
       },
       types: "lib/index.d.ts",
       devDependencies: {
-        "@tsconfig/node18": "^18.0.0",
+        "@tsconfig/node20": "^20.0.0",
         "@types/node": "^18.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -79,7 +79,8 @@ export default async function (root: string, variables: Variables) {
         "typescript": "^5.0.0"
       },
       removeDependencies: [
-        "@types/tap"
+        "@types/tap",
+        "@tsconfig/node18"
       ]
     }),
     "tsconfig.json": json({

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -67,22 +67,20 @@ export default async function (root: string, variables: Variables) {
           }
         ),
       },
-      tap: {
-        coverage: true,
-        ts: true,
-      },
       types: "lib/index.d.ts",
       devDependencies: {
         "@tsconfig/node18": "^18.0.0",
         "@types/node": "^18.0.0",
-        "@types/tap": "^15.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.0.0",
-        "tap": "^16.0.0",
+        "tap": "^18.7.0",
         "ts-node": "^10.0.0",
         "typescript": "^5.0.0"
       },
+      removeDependencies: [
+        "@types/tap"
+      ]
     }),
     "tsconfig.json": json({
       set: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -87,7 +87,7 @@ export default async function (root: string, variables: Variables) {
     "tsconfig.json": json({
       set: {
         "//": "This file is partially managed by code-skeleton. Changes may be overwritten.",
-        extends: "@tsconfig/node18/tsconfig.json",
+        extends: "@tsconfig/node20/tsconfig.json",
       },
       append: {
         include: [

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -76,8 +76,15 @@ export default async function (root: string, variables: Variables) {
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.0.0",
         "tap": "^18.7.0",
-        "ts-node": "^10.0.0",
+        "tsx": "4.2.1",
         "typescript": "^5.0.0"
+      },
+      "overrides": {
+        // Needed with the 4.2.1 tsx version lock to fix code coverage
+        // https://github.com/privatenumber/tsx/issues/433
+        "@tapjs/tsx": {
+          "tsx": "$tsx"
+        }
       },
       removeDependencies: [
         "@types/tap",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -66,6 +66,7 @@ export default async function (root: string, variables: Variables) {
             prepack: "tsc --project tsconfig.build.json",
           }
         ),
+        postinstall: "tap build",
       },
       types: "lib/index.d.ts",
       devDependencies: {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@tapjs/sinon": "^1.1.18",
     "@tapjs/tsx": "^1.1.19",
-    "@tsconfig/node18": "^18.0.0",
+    "@tsconfig/node20": "^20.0.0",
     "@types/mustache": "^4.0.0",
     "@types/node": "^18.0.0",
     "@types/sinon": "^17.0.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "mustache": "^4.2.0"
   },
   "devDependencies": {
+    "@istanbuljs/esm-loader-hook": "^0.2.0",
+    "@tapjs/esbuild-kit": "^1.1.19",
     "@tapjs/sinon": "^1.1.18",
     "@tapjs/tsx": "^1.1.19",
     "@tsconfig/node20": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@tapjs/tsx": "^1.1.19",
     "@tsconfig/node20": "^20.0.0",
     "@types/mustache": "^4.0.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "@types/sinon": "^17.0.3",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "postlint": "npm run skeleton:verify",
     "skeleton:apply": "code-skeleton apply",
     "preskeleton:verify": "npm run prepack",
-    "skeleton:verify": "code-skeleton verify"
+    "skeleton:verify": "code-skeleton verify",
+    "postinstall": "tap build"
   },
   "keywords": [],
   "author": "Nathan LaFreniere <nlf@nlf.sh>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4rena/skeleton",
-  "version": "2.0.0-1",
+  "version": "2.0.0-2",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4rena/skeleton",
-  "version": "1.2.1",
+  "version": "2.0.0-0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@tapjs/sinon": "^1.1.18",
+    "@tapjs/tsx": "^1.1.19",
     "@tsconfig/node18": "^18.0.0",
     "@types/mustache": "^4.0.0",
     "@types/node": "^18.0.0",
@@ -32,7 +33,7 @@
     "eslint": "^8.0.0",
     "tap": "^18.7.0",
     "ts-node": "^10.0.0",
-    "typescript": "5.2.2"
+    "typescript": "^5.3.3"
   },
   "peerDependencies": {
     "code-skeleton": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "mustache": "^4.2.0"
   },
   "devDependencies": {
-    "@istanbuljs/esm-loader-hook": "^0.2.0",
-    "@tapjs/esbuild-kit": "^1.1.19",
     "@tapjs/sinon": "^1.1.18",
     "@tapjs/tsx": "^1.1.19",
     "@tsconfig/node20": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4rena/skeleton",
-  "version": "2.0.0-0",
+  "version": "2.0.0-1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint": "^8.0.0",
     "tap": "^18.7.0",
     "ts-node": "^10.0.0",
-    "typescript": "^5.3.3"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "code-skeleton": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -22,14 +22,15 @@
     "mustache": "^4.2.0"
   },
   "devDependencies": {
+    "@tapjs/sinon": "^1.1.18",
     "@tsconfig/node18": "^18.0.0",
     "@types/mustache": "^4.0.0",
     "@types/node": "^18.0.0",
-    "@types/tap": "^15.0.0",
+    "@types/sinon": "^17.0.3",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
-    "tap": "^16.0.0",
+    "tap": "^18.7.0",
     "ts-node": "^10.0.0",
     "typescript": "5.2.2"
   },
@@ -54,9 +55,5 @@
     "lib/**/*.d.ts",
     "!lib/types/**",
     "lib/content/**"
-  ],
-  "tap": {
-    "coverage": true,
-    "ts": true
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,16 @@
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
     "tap": "^18.7.0",
-    "ts-node": "^10.0.0",
-    "typescript": "5.2.2"
+    "tsx": "4.2.1",
+    "typescript": "^5.0.0"
   },
   "peerDependencies": {
     "code-skeleton": "^2.0.0"
+  },
+  "overrides": {
+    "@tapjs/tsx": {
+      "tsx": "$tsx"
+    }
   },
   "skeleton": {
     "module": ".",

--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env tsx
 // This file is managed by code-skeleton. Do not make changes.
 
 import { rmSync } from "node:fs";

--- a/scripts/update-shebang.ts
+++ b/scripts/update-shebang.ts
@@ -1,11 +1,11 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env tsx
 
 import { spawnSync } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
 const ROOT = dirname(__dirname);
-const tsShebang = "#!/usr/bin/env ts-node";
+const tsShebang = "#!/usr/bin/env tsx";
 const jsShebang = "#!/usr/bin/env node";
 
 async function updateShebang (path: string) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,0 @@
-import t from "tap";
-
-void t.test("this is not a real test", (t) => {
-  t.pass();
-  t.end();
-});

--- a/test/mustache.test.ts
+++ b/test/mustache.test.ts
@@ -1,5 +1,5 @@
 import t from "tap";
-import { mustache } from "../lib/mustache.ts";
+import { mustache } from "../lib/mustache";
 
 void t.test("mustache", async (t) => {
   await t.test("must include a path", (t) => {
@@ -9,7 +9,7 @@ void t.test("mustache", async (t) => {
   });
 
   await t.test("should generate", async (t) => {
-    const { mustache } = t.mockRequire<typeof import("../lib/mustache.ts")>("../lib/mustache.ts", {
+    const { mustache } = t.mockRequire<typeof import("../lib/mustache")>("../lib/mustache", {
       "node:fs/promises": {
         readFile: (path: string) => {
           t.equal(path, "path/to/file.txt");
@@ -31,7 +31,7 @@ void t.test("mustache", async (t) => {
   });
 
   await t.test("should validate partials", async (t) => {
-    const { mustache } = t.mockRequire<typeof import("../lib/mustache.ts")>("../lib/mustache.ts", {
+    const { mustache } = t.mockRequire<typeof import("../lib/mustache")>("../lib/mustache", {
       "node:fs/promises": {
         readFile: () => Promise.resolve("<% title %>")
       }
@@ -59,7 +59,7 @@ void t.test("mustache", async (t) => {
   });
 
   await t.test("should fail validation when base template not found", async (t) => {
-    const { mustache } = t.mockRequire<typeof import("../lib/mustache.ts")>("../lib/mustache.ts", {
+    const { mustache } = t.mockRequire<typeof import("../lib/mustache")>("../lib/mustache", {
       "node:fs/promises": {
         readFile: () => Promise.resolve("<% title %>")
       }

--- a/test/mustache.test.ts
+++ b/test/mustache.test.ts
@@ -1,0 +1,91 @@
+import t from "tap";
+import { mustache } from "../lib/mustache.ts";
+
+void t.test("mustache", async (t) => {
+  await t.test("must include a path", (t) => {
+    // @ts-expect-error bad data on purpose
+    t.throws(() => mustache({}));
+    t.end();
+  });
+
+  await t.test("should generate", async (t) => {
+    const { mustache } = t.mockRequire<typeof import("../lib/mustache.ts")>("../lib/mustache.ts", {
+      "node:fs/promises": {
+        readFile: (path: string) => {
+          t.equal(path, "path/to/file.txt");
+          return Promise.resolve("<% title %>");
+        }
+      }
+    });
+    const variables = {
+      title: "it generates"
+    };
+
+    const generator = mustache({
+      path: "path/to/file.txt",
+      variables,
+    });
+
+    const output = await generator.generate();
+    t.equal(output, "it generates");
+  });
+
+  await t.test("should validate partials", async (t) => {
+    const { mustache } = t.mockRequire<typeof import("../lib/mustache.ts")>("../lib/mustache.ts", {
+      "node:fs/promises": {
+        readFile: () => Promise.resolve("<% title %>")
+      }
+    });
+    const variables = {
+      title: "it generates"
+    };
+
+    const generator = mustache({
+      path: "path/to/file.txt",
+      variables,
+    });
+
+    const generateSpy = t.sinon.spy(generator, "generate");
+    const reportSpy = t.sinon.spy(generator, "report");
+
+    await generator.validate({
+      path: "path/to/file.txt",
+      found: "it generates\nand handles extras"
+    });
+
+    t.equal(generateSpy.callCount, 1);
+    // Report not called because we passed
+    t.equal(reportSpy.callCount, 0);
+  });
+
+  await t.test("should fail validation when base template not found", async (t) => {
+    const { mustache } = t.mockRequire<typeof import("../lib/mustache.ts")>("../lib/mustache.ts", {
+      "node:fs/promises": {
+        readFile: () => Promise.resolve("<% title %>")
+      }
+    });
+    const variables = {
+      title: "it generates"
+    };
+
+    const generator = mustache({
+      path: "path/to/file.txt",
+      variables,
+    });
+
+    const generateSpy = t.sinon.spy(generator, "generate");
+    const reportSpy = t.sinon.spy(generator, "report");
+
+    await generator.validate({
+      path: "path/to/file.txt",
+      found: "a new file"
+    });
+
+    t.equal(generateSpy.callCount, 1);
+    t.ok(reportSpy.calledOnceWithExactly({
+      expected: "it generates",
+      found: "a new file",
+      message: "path/to/file.txt does not include the original template"
+    }));
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,8 @@
     "./lib/content/**"
   ],
   "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "noEmit": false,
     "declaration": true
   },
   "//": "This file is partially managed by code-skeleton. Changes may be overwritten."

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,8 +6,6 @@
     "./lib/content/**"
   ],
   "compilerOptions": {
-    "allowImportingTsExtensions": false,
-    "noEmit": false,
     "declaration": true
   },
   "//": "This file is partially managed by code-skeleton. Changes may be overwritten."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "include": [
     "**/*.ts",
     ".eslintrc.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     ".eslintrc.js"
   ],
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "typeRoots": [
       "./node_modules/@types",
       "./lib/types"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,6 @@
     ".eslintrc.js"
   ],
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
-    "noEmit": true,
     "typeRoots": [
       "./node_modules/@types",
       "./lib/types"


### PR DESCRIPTION
## Summary

BREAKING CHANGE: This update is not backwards compatible with previous versions of testing.

This supercedes #9.

### Highlights
* Updates to node 20 from node 18, including TS config
* Updates tap from v16 to v18
* .taprc added to skeleton gitignore
* Skeleton tests include examples of mocking node modules and using @tapjs/sinon for spying
* Added a postinstall script to automatically build tap plugins

Prerelease for testing at `npm i -D @code4rena/skeleton@2.0.0-0`

## Known issues

- **Cannot find tsconfig error**: I've added a workaround to the readme, which is also included in the taprc file of this project to get around tsconfig files not being found.
- **Coverage not reporting in CI**: I'm still looking into this, but code coverage is not being generated in CI, despite reporting working locally.

