### PR TITLE
add benchmark directory to gitignore whitelists

### DIFF
--- a/lib/content/gitignore
+++ b/lib/content/gitignore
@@ -27,6 +27,7 @@
 !/test/
 !/tsconfig*.json
 !/heroku.yml
+!/benchmark/
 
 # re-ignore typescript output artifacts
 /knexfile.js


### PR DESCRIPTION
To allow autocannon stuff to live in